### PR TITLE
Bugfix in cubegen of sen2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-## Changes in 0.1.1 (under development)
+## Changes in 0.1.1
+
+* Fixed a bug in Sentinel-2 cube generation where, during mosaicking of adjacent tiles 
+  from the same solar day, data from one spectral band would overwrite all other bands 
+  in the final cube.
 
 
 ## Changes in 0.1.0

--- a/xcube_eopf/prodhandlers/sentinel2.py
+++ b/xcube_eopf/prodhandlers/sentinel2.py
@@ -716,7 +716,7 @@ def _create_empty_dataset(
     )
     ds = xr.Dataset(
         {
-            key: (("time", "y", "x"), empty_data.astype(var))
+            key: (("time", "y", "x"), empty_data.copy().astype(var))
             for (key, var) in sample_ds.data_vars.items()
         },
         coords={


### PR DESCRIPTION
Fixed a bug in Sentinel-2 cube generation where, during mosaicking of adjacent tiles from the same solar day, data from one spectral band would overwrite all other bands in the final cube.