### PR TITLE
Install via pip fixed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "pystac-client",
   "xarray",
   "xarray-eopf>=0.1.1",
-  "xcube>=1.11.0"
+  "xcube-core>=1.11.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
I tested the setup locally by creating a new Conda environment with:

```
conda create -n myenv -c conda-forge python=3.12 pip sqlite gdal
```

After activating the environment, I installed the package using:
```
pip install .
```

> ⚠️ Important: I explicitly included `sqlite` and `gdal` during environment creation. This ensures that compatible versions are installed directly from conda-forge.

If these packages are not specified at creation time, conda may attempt to pull them from the base environment, which can lead to conflicts — especially when different Python versions require different `sqlite` or `gdal` builds.

This exact issue occurred on my system when I omitted them, so it’s safer to include these dependencies explicitly up front.